### PR TITLE
6857 Remove useless replacement of text in AdminActivityLogPageActionTest

### DIFF
--- a/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
@@ -450,8 +450,7 @@ public class AdminActivityLogPageActionTest extends BaseActionTest {
         assertEquals(expectedMsgs.size(), actualLogs.size());
         for (int i = 0; i < expectedMsgs.size(); i++) {
             String actualMsg = actualLogs.get(i).generateLogMessage();
-            actualMsg = actualMsg.replace("<mark>", "").replace("</mark>", "");
-            assertTrue("expecte: " + expectedMsgs.get(i) + "to contain:" + actualMsg,
+            assertTrue("expected: " + expectedMsgs.get(i) + "to contain:" + actualMsg,
                     expectedMsgs.get(i).contains(actualMsg));
         }
     }


### PR DESCRIPTION
Removed useless line from AdminActivityLogPageActionTest per xpdavid's
instructions.